### PR TITLE
Change the main file to ./build/icono.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "icono",
   "version": "0.9.5",
   "description": "Pure CSS Icons",
-  "main": "gulpfile.js",
+  "main": "./build/icono.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/saeedalipoor/icono.git"


### PR DESCRIPTION
So that when importing icono using webpack's CSS loader, we can simply do `@import '~icono';` instead of `@import '~icono/build/icono.css';`.